### PR TITLE
Fixed tests, in theory

### DIFF
--- a/arrays_tests.scala
+++ b/arrays_tests.scala
@@ -112,9 +112,9 @@ class RationalScalaTestFlatSpecMatchers extends FlatSpec with Matchers {
     getAscendingRun(a, 0) should be (3)
     getAscendingRun(a, 3) should be (6)
     getAscendingRun(a, 6) should be (7)
-    getAscendingRun(a, 7) should be (9)
-    getAscendingRun(a, 9) should be (11)
-    getAscendingRun(a, 11) should be (13)
+    getAscendingRun(a, 7) should be (15)
+    getAscendingRun(a, 9) should be (15)
+    getAscendingRun(a, 11) should be (15)
   }
 
   "getRunsAsString()" should "work with the provided example" in {
@@ -124,7 +124,7 @@ class RationalScalaTestFlatSpecMatchers extends FlatSpec with Matchers {
 
   it should "also work with different data" in {
     val a = Array(2, 5, 8, 3, 9, 9, 8, 6, 6, 4, 4, 2, 2, 0, 0)
-    getRunsAsString(a) should be ("2, 5, 8 | 3, 9, 9 | 8 | 6, 6 | 4, 4 | 2, 2 | 0, 0 |")
+    getRunsAsString(a) should be ("2, 5, 8 | 3, 9, 9 | 8 | 6, 6 | 4, 4 | 2, 2 | 0, 0")
   }
 }
 


### PR DESCRIPTION
For the first test I fixed here is why I believe it needed fixing:

We are concerned with this part of the array in the test: 3, 3, 4, 4, 5, 5, 6, 6. This is indeed increasing by how you guys define increasing (x_{n+1} >= x_n), so the run should include all the numbers until the end. If you want to define increasing as strictly increasing (i.e. x_{n+1} > x_n) then you need to fix the first part of the test above (that is 3, 9, 9 should stop after the first 9, but according to the example it does not).

For the second test:

In the first part of this test you don't have a hanging pipe (e.g. at the end there is no extra `|` symbol), but in this test you do. I chose no hanging pipe to keep the strings symmetric (there is no beginning pipe either)

Let me know if I misinterpreted anything and these tests were specifically created these ways.
